### PR TITLE
adding fedora 3.7.0 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 php:
   - 5.3.3
-  #- 5.4
+  - 5.4
 branches:
   only:
     - 7.x
 env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
+  - FEDORA_VERSION="3.7.0"
 before_install:
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git


### PR DESCRIPTION
Also re-enabling PHP 5.4 testing. I'm told it's broken. That's coo.
