### PR TITLE
Find values with '#parents' structure.

### DIFF
--- a/Form.inc
+++ b/Form.inc
@@ -3,7 +3,7 @@
 /**
  * @file
  * Defines a class that allows drupal forms to be built via objects instead of
- * arrays. Note that is still possible to build non functional drupal forms 
+ * arrays. Note that is still possible to build non functional drupal forms
  * using this class, the same rules apply that would normally apply to a Drupal
  * API
  * Form.
@@ -59,7 +59,7 @@ class Form implements ArrayAccess {
 
   /**
    * Function ajaxAlter.
-   * 
+   *
    * Apply ajax alters to the form.
    *
    * @var FormElementRegistry
@@ -91,7 +91,7 @@ class Form implements ArrayAccess {
 
   /**
    * Function hasElement.
-   * 
+   *
    * Checks to see if the FormElement identified by its unique $hash exists in
    * this form.
    *
@@ -124,7 +124,7 @@ class Form implements ArrayAccess {
 
   /**
    * Function duplicateOriginal.
-   * 
+   *
    * Duplicates a FormElement identified by its unique $hash from its original
    * definition.
    *

--- a/FormElement.inc
+++ b/FormElement.inc
@@ -685,6 +685,8 @@ class FormElement implements ArrayAccess {
    * Used to reliably access values posted back from the user.
    *
    * @return array
+   *   An array of indicies, including this element's, to use to access the
+   *   value for this element in $form_state['values'].
    */
   public function getParentsArray() {
     if ($this->parent === NULL) {

--- a/FormElement.inc
+++ b/FormElement.inc
@@ -184,7 +184,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function flatten.
-   * 
+   *
    * Converts the tree like structure of a FormElement and its children to a
    * flat array.
    *
@@ -204,7 +204,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function eachChild.
-   * 
+   *
    * Takes a callback, and calls it repeatedly passing each child FormElement
    * to the callback as the first parameter. Any other parameters passed to this
    * function will be passed to the callback as additional parameters.
@@ -236,7 +236,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function eachControl.
-   * 
+   *
    * Takes a callback, and calls it repeatedly passing each control/property to
    * the callback with the name of the control/property as the first parameter
    * and the value of the control/property as the second paramter. Any other
@@ -267,7 +267,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function eachDecendant.
-   * 
+   *
    * Takes a callback, and calls it repeatedly passing each decendant
    * FormElement to the callback as the first parameter. Any other parameters
    * passed to this function will be passed to the callback as additional
@@ -280,7 +280,7 @@ class FormElement implements ArrayAccess {
    *
    * @param callback $function
    *   The function to be called repeatedly.
-   * 
+   *
    * @return bool
    *   TRUE if the function was called for all decendants, FALSE otherwise.
    */
@@ -307,7 +307,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function each.
-   * 
+   *
    * Takes a callback, and calls it repeatedly passing itself and each decendant
    * FormElement to the callback as the first parameter. Any other parameters
    * passed to this function will be passed to the callback as additional
@@ -320,7 +320,7 @@ class FormElement implements ArrayAccess {
    *
    * @param callback $function
    *   The function to be called repeatedly.
-   * 
+   *
    * @return bool
    *   TRUE if the function was called for all decendants, FALSE otherwise.
    */
@@ -336,14 +336,14 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function __get.
-   * 
+   *
    * Gets a child FormElement, control/property, or ProtectedReadOnlyMember if
    * it exists.
    *
    * @param mixed $name
    *   The name of the child FormElement, control/property, or
    *   ProtectedReadOnlyMember.
-   * 
+   *
    * @return mixed
    *   The child FormElement, control/property, or ProtectedReadOnlyMember
    *   identified by $name if found, NULL otherwise.
@@ -365,7 +365,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function __set.
-   * 
+   *
    * Adds/Sets the value for a child FormElement, control/property, or
    * ProtectedReadOnlyMember.
    *
@@ -390,7 +390,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function __isset.
-   * 
+   *
    * Checks if a given child FormElement or a control/property identified by
    * $name exists. Also checks for the existance of values stored in this
    * objects ReadOnlyMembers.
@@ -412,7 +412,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function __unset.
-   * 
+   *
    * Unsets a given child FormElement, control/property, or
    * ProtectedReadOnlyMember identified by $name.
    *
@@ -436,7 +436,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function offsetExists.
-   * 
+   *
    * Checks if a given child FormElement or a control/property identified by
    * $offsets exists.
    *
@@ -454,13 +454,13 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function offsetGet.
-   * 
+   *
    * Gets a the child FormElement or a control/property identified by $offset
    * if it exists.
    *
    * @param mixed $offset
    *   The name of the child FormElement or control/property.
-   * 
+   *
    * @return mixed
    *   If found, this function will return either a child FormElement or a
    *   FormControl.
@@ -477,7 +477,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function offsetSet.
-   * 
+   *
    * Adds/Sets a child FormElement or a control/property identified by $offset
    * if it exists.
    *
@@ -498,7 +498,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function offsetUnset.
-   * 
+   *
    * Unsets a given child FormElement or control/property identified by $offset.
    *
    * @param mixed $offset
@@ -515,7 +515,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function adopt.
-   * 
+   *
    * Adopt the child FormElement, this forcefully orphans the child from its
    * original parent.
    *
@@ -540,7 +540,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function setParent.
-   * 
+   *
    * Sets this FormElements parent to the one provided. Orphaning this
    * FormElement from its previous parent FormElement.
    *
@@ -555,7 +555,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function orphan.
-   * 
+   *
    * Orphans this FormElement, and removes the relationship its parent
    * FormElement has with it.
    *
@@ -573,7 +573,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function orphanChild.
-   * 
+   *
    * Removes the child element defined by $remove from this FormElement.
    *
    * @param FormElement $remove
@@ -594,7 +594,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Funciton getIndex.
-   * 
+   *
    * Get's the index of this FormElement in its parent's children array if it
    * has a parent.
    *
@@ -618,7 +618,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function getLocation.
-   * 
+   *
    * Gets the full path in the form definition to this element.
    *
    * @return string
@@ -632,7 +632,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function toArray.
-   * 
+   *
    * Converts this FormElement into an array that can be used with the Drupal
    * Form API, as a form definition.
    *
@@ -648,7 +648,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function addControlsToArray.
-   * 
+   *
    * Converts this FormElements controls/properties to an array that can be
    * used by Drupal Form API.
    *
@@ -666,7 +666,7 @@ class FormElement implements ArrayAccess {
 
   /**
    * Function addChildrenToArray.
-   * 
+   *
    * Converts this FormElements child FormElements to an array that can be used
    * by Drupal Form API.
    *

--- a/FormElement.inc
+++ b/FormElement.inc
@@ -50,13 +50,21 @@ class FormElement implements ArrayAccess {
    */
   protected $registry;
 
+
+  /**
+   * Index of the current element, within its parent.
+   *
+   * @var string|int
+   */
+  protected $index;
+
   /**
    * Instantiate's a FormElement.
    *
    * @param array $form
    *   Drupal form definition.
    */
-  public function __construct(FormElementRegistry $registry = NULL /* yuck fix this.. */, array $form = NULL) {
+  public function __construct(FormElementRegistry $registry = NULL /* yuck fix this.. */, array $form = NULL, $index = NULL) {
     $this->protected = new ReadOnlyProtectedMembers(array('parent' => NULL, 'hash' => NULL));
     $this->registry = $registry;
     $this->controls = array();
@@ -67,6 +75,7 @@ class FormElement implements ArrayAccess {
     if ($this->registry) {
       $this->registry->registerCreated($this);
     }
+    $this->index = $index;
   }
 
   /**
@@ -109,7 +118,7 @@ class FormElement implements ArrayAccess {
   protected function initializeChildren(array &$form) {
     $children = element_children($form);
     foreach ($children as $key) {
-      $child = new FormElement($this->registry, $form[$key]);
+      $child = new FormElement($this->registry, $form[$key], $key);
       $this->adopt($child, $key);
     }
   }
@@ -594,6 +603,9 @@ class FormElement implements ArrayAccess {
    *   has no parent.
    */
   public function getIndex() {
+    if ($this->index !== NULL) {
+      return $this->index;
+    }
     if (isset($this->parent)) {
       foreach ($this->parent->children as $index => $child) {
         if ($child === $this) {
@@ -667,4 +679,29 @@ class FormElement implements ArrayAccess {
     }
   }
 
+  /**
+   * Get array of parents, similar to Drupal's '#parents'.
+   *
+   * Used to reliably access values posted back from the user.
+   *
+   * @return array
+   */
+  public function getParentsArray() {
+    if ($this->parent === NULL) {
+      // Should only be the top-level "form" element.
+      return array();
+    }
+    elseif (isset($this['#parents'])) {
+      // Potential optimization... Unlikely to hit?
+      return $this['#parents'];
+    }
+    else {
+      if (isset($this['#tree']) && $this['#tree']) {
+        return array_merge($this->parent->getParentsArray(), array($this->getIndex()));
+      }
+      else {
+        return array();
+      }
+    }
+  }
 }

--- a/FormElementRegistry.inc
+++ b/FormElementRegistry.inc
@@ -67,7 +67,7 @@ class FormElementRegistry {
 
   /**
    * Function registerDestroyed.
-   * 
+   *
    * Should this ever get called? Since this class holds references to every
    * object created.
    *
@@ -109,7 +109,7 @@ class FormElementRegistry {
 
   /**
    * Function isClone.
-   * 
+   *
    * Checks to see if the form element identified by its hash is a clone of
    * another form element.
    *
@@ -126,7 +126,7 @@ class FormElementRegistry {
 
   /**
    * Function hasAncestor.
-   * 
+   *
    * Checks if a FormElement has a ancestor it was cloned from at the given
    * depth.
    *
@@ -163,8 +163,8 @@ class FormElementRegistry {
   }
 
   /**
-   * Function setAncestory. 
-   * 
+   * Function setAncestory.
+   *
    * Sets the history for a given element and the hash of the element in which
    * it was cloned from.
    *
@@ -182,7 +182,7 @@ class FormElementRegistry {
 
   /**
    * Function getAncestor.
-   * 
+   *
    * Gets the ancestor this FormElement was cloned from at the given depth in
    * its cloned.
    *
@@ -226,7 +226,7 @@ class FormElementRegistry {
 
   /**
    * Function clearAncestory.
-   * 
+   *
    * Clears the ancestory of the given FormElement, or if no FormElement is
    * provided the ancestory of all FormElements will be clear.
    *

--- a/FormPopulator.inc
+++ b/FormPopulator.inc
@@ -32,7 +32,7 @@ class FormPopulator {
 
   /**
    * Function populate.
-   * 
+   *
    * Populates a Drupal Form's elements #default_value properties with POST
    * data.
    *

--- a/FormPropertyInterface.inc
+++ b/FormPropertyInterface.inc
@@ -13,7 +13,7 @@ interface FormPropertyInterface {
 
   /**
    * Function __constructor.
-   * 
+   *
    * Creates the FormProperty object from its scalar or array Drupal Form
    * Property value.
    *

--- a/FormValueTracker.inc
+++ b/FormValueTracker.inc
@@ -69,97 +69,12 @@ class FormValueTracker {
    *   Submitted value for the given FormElement if found, NULL otherwise.
    */
   public function getValue(array &$element) {
-    module_load_include('inc', 'objective_forms', 'FormElementRegistry');
-    $value = $this->track($element);
-    // Array's are roots of #tree branchs.
+    if (!isset($element['#hash'])) {
+      return NULL;
+    }
+
+    $form_element = $this->registry->get($element['#hash']);
+    $value = drupal_array_get_nested_value($this->current, $form_element->getParentsArray());
     return is_array($value) ? NULL : $value;
   }
-
-  /**
-   * Get this elements index in its parent.
-   *
-   * @param array $element
-   *   An element in the Drupal Form.
-   *
-   * @return mixed
-   *   The index of the element if found, NULL otherwise.
-   */
-  protected function getIndex(array &$element) {
-    if (isset($element['#array_parents'])) {
-      $parents = $element['#array_parents'];
-      return array_pop($parents);
-    }
-    elseif (isset($element['#hash'])) {
-      $found = $this->registry->get($element['#hash']);
-      if ($found) {
-        return $found->getIndex();
-      }
-    }
-    return NULL;
-  }
-
-  /**
-   * Function track.
-   * 
-   * Update the $current pointer so that it is pointing at the correct value.
-   * Return the current position.
-   *
-   * @param array $element
-   *   An element in the Drupal Form.
-   *
-   * @return mixed
-   *   The value of the current position in the values tree. Typically a array
-   *   or a scalar value.
-   */
-  protected function track(array &$element) {
-    if ($this->shouldStartTracking($element)) {
-      $this->track = TRUE;
-    }
-    if ($this->shouldStopTracking($element)) {
-      $this->track = FALSE;
-      $this->reset();
-    }
-    $index = $this->getIndex($element);
-    if ($this->track && isset($this->current[$index])) {
-      $this->current = &$this->current[$index];
-      return $this->current;
-    }
-    return isset($this->current[$index]) ? $this->current[$index] : NULL;
-  }
-
-  /**
-   * Checks if the tracker should begin tracking.
-   *
-   * @param array $element
-   *   An element in the Drupal Form.
-   *
-   * @return bool
-   *   TRUE if the tracker should start to track values, FALSE if it is already
-   *   tracking or shouldn't start tracking.
-   */
-  protected function shouldStartTracking(array &$element) {
-    return (isset($element['#tree']) && $element['#tree'] === TRUE) && !$this->track;
-  }
-
-  /**
-   * Checks if the tracker should stop tracking.
-   *
-   * @param array $element
-   *   An element in the Drupal Form.
-   *
-   * @return bool
-   *   TRUE if the tracker should stop tracking values, FALSE if it is not
-   *   tracking or should continue tracking.
-   */
-  protected function shouldStopTracking(array &$element) {
-    return (isset($element['#tree']) && $element['#tree'] === FALSE) && $this->track;
-  }
-
-  /**
-   * Reset the $current pointer to the top level of the $values array.
-   */
-  protected function reset() {
-    $this->current = &$this->values;
-  }
-
 }

--- a/Utils.inc
+++ b/Utils.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Utility functions
+ * Utility functions.
  */
 
 module_load_include('inc', 'php_lib', 'Array');
@@ -25,7 +25,7 @@ function &find_element(array &$form, $hash) {
 
 /**
  * Function find_child_elements.
- * 
+ *
  * Recursively searches the Drupal Form elements children for the element that
  * matches the given hash.
  *
@@ -52,7 +52,7 @@ function &find_child_element(array &$form, $hash) {
 
 /**
  * Functin has_hash.
- * 
+ *
  * Checks to see if the given drupal form element has a #hash property and
  * checks to see if it matches the given hash.
  *
@@ -96,7 +96,7 @@ function form_element_name(array $element) {
 
 /**
  * Function form_element_is_child.
- * 
+ *
  * Compares two Drupal form element names to determine if the second
  * argument is a child element of the first.
  *

--- a/objective_forms.module
+++ b/objective_forms.module
@@ -8,7 +8,7 @@
 
 /**
  * Function Menu.
- * 
+ *
  * !TEST CODE -- Needed for some Simple Tests!
  */
 function objective_forms_menu() {
@@ -28,7 +28,7 @@ function objective_forms_menu() {
  *
  * @param string $form_name
  *   The name of the form
- * 
+ *
  * @return html
  *   Returns the html
  */
@@ -41,8 +41,8 @@ function objective_forms_test($form_name) {
 
 /**
  * Function test_load_files.
- * 
- * Include all the test files so we can find the proper function for getting 
+ *
+ * Include all the test files so we can find the proper function for getting
  * the file.
  */
 function objective_forms_test_load_files() {

--- a/tests/Form.test
+++ b/tests/Form.test
@@ -23,7 +23,7 @@ class ObjectiveFormTestCase extends DrupalUnitTestCase {
 
   /**
    * Function setup.
-   * 
+   *
    * setUp() performs any pre-requisite tasks that need to happen.
    */
   public function setUp() {


### PR DESCRIPTION
... Or at least a similarly-built structure... The old method of "tracking" would lead to false-positives when fields were similarly named at different levels in the hierarchy, so something as follows would have the potential to break down:

```
authors
- 0
-- given
-- family
host
- authors
-- 0
--- given
--- family
```

didn't seem to cause errors in output of eventual submissions ('cause we're only changing the things we're AJAXing)...

PHP errors start popping up if the structure varies slightly... Say that host authors use a `tags`/`tag` structure to allow multiple values for both given and family names instead of a plain `textfield`.
